### PR TITLE
Removed unnecessary Apache dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,7 +9,6 @@ project_page 'https://github.com/puppetlabs/puppetlabs-havana'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/openstack', '>=3.0.0 <4.0.0'
-dependency 'puppetlabs/apache', '0.8.0'
 dependency 'puppetlabs/ntp', '>=2.0.0 <3.0.0'
 dependency 'puppetlabs/firewall', '>=0.0.4 <1.0.0'
 dependency 'puppetlabs/vswitch', '>=0.2.0 <1.0.0'


### PR DESCRIPTION
Before this change, the module depened on Apache 0.8.0. This would
cause conflicts with inifile dependencies. This change removed
the dependency and fixes the conflict when installed with
Puppet Module Tool.
