### PR TITLE
Fixed keystone roles. Added mongodb database/user

### DIFF
--- a/manifests/profile/ceilometer/api.pp
+++ b/manifests/profile/ceilometer/api.pp
@@ -1,4 +1,4 @@
-# The profile to set up the Ceilometer API
+#The profile to set up the Ceilometer API
 class havana::profile::ceilometer::api {
   $api_device = hiera('havana::network::api::device')
   $management_device = hiera('havana::network::management::device')
@@ -63,5 +63,20 @@ class havana::profile::ceilometer::api {
 
   class { '::havana::profile::ceilometer::common':
     is_controller => true,
+  }
+
+  mongodb_database { 'ceilometer':
+    ensure  => present,
+    tries   => 10,
+    require => Class['mongodb::server'],
+  }
+
+  mongodb_user { 'ceilometer':
+    ensure        => present,
+    password_hash => mongodb_password('ceilometer', 'password'),
+    database      => ceilometer,
+    roles         => ['readWrite', 'dbAdmin'],
+    tries         => 10,
+    require       => Class['mongodb::server'],
   }
 }

--- a/manifests/resources/user.pp
+++ b/manifests/resources/user.pp
@@ -15,12 +15,12 @@ define havana::resources::user (
   
   if $admin == true { 
     keystone_user_role { "$name@$tenant": 
-      roles  => ['Member', 'admin'], 
+      roles  => ['_member_', 'admin'],
       ensure => present, 
     } 
   } else { 
     keystone_user_role { "$name@$tenant": 
-      roles  => ['Member'], 
+      roles  => ['_member_'],
       ensure => present, 
     } 
   }


### PR DESCRIPTION
Before this change, the default member role did not match the
Keystone defaults. A user and database were not created
for MongoDB and Ceilometer. This change corrects the member
role and adds the MongoDB database and user.
