### PR TITLE
Updated example to install and connect PuppetDB

### DIFF
--- a/examples/vagrant/10_setup_master.sh
+++ b/examples/vagrant/10_setup_master.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # Set up the Puppet Master
-vagrant ssh puppet -c "sudo service iptables stop; \
+vagrant ssh puppet -c "sudo yum install puppetdb; \
+sudo service iptables stop; \
+sudo service puppetmaster stop; \
+sudo puppet module install puppetlabs/puppetdb; \
+sudo puppet apply --modulepath /etc/puppet/modules -e \"class { '::puppetdb': listen_address => '0.0.0.0', ssl_listen_address => '0.0.0.0' }\"; \
+sudo puppet resource package puppetdb-terminus ensure=latest; \
 sudo puppet module install puppetlabs/ntp; \
 sudo puppet module install puppetlabs/firewall; \
 sudo puppet module install puppetlabs/mysql --version 0.6.1; \
@@ -19,5 +24,9 @@ sudo mkdir /etc/puppet/hieradata; \
 sudo chown root:puppet /etc/puppet/hieradata; \
 sudo cp /etc/puppet/modules/havana/examples/common.yaml /etc/puppet/hieradata/common.yaml; \
 sudo chown root:puppet /etc/puppet/hieradata/common.yaml; \
+sudo cp /vagrant/puppet.conf /etc/puppet/puppet.conf; \
+sudo cp /vagrant/puppetdb.conf /etc/puppet/puppetdb.conf; \
+sudo cp /vagrant/routes.yaml /etc/puppet/routes.yaml; \
+sudo chown puppet:root /etc/puppet/puppet.conf /etc/puppet/puppetdb.conf /etc/puppet/routes.yaml; \
 sudo service puppetmaster start;\
 sudo puppet agent -t"

--- a/examples/vagrant/puppet.conf
+++ b/examples/vagrant/puppet.conf
@@ -1,0 +1,31 @@
+[main]
+    # The Puppet log directory.
+    # The default value is '$vardir/log'.
+    logdir = /var/log/puppet
+
+    # Where Puppet PID files are kept.
+    # The default value is '$vardir/run'.
+    rundir = /var/run/puppet
+
+    # Where SSL certificates are kept.
+    # The default value is '$confdir/ssl'.
+    ssldir = $vardir/ssl
+
+[agent]
+    # The file in which puppetd stores a list of the classes
+    # associated with the retrieved configuratiion.  Can be loaded in
+    # the separate ``puppet`` executable using the ``--loadclasses``
+    # option.
+    # The default value is '$confdir/classes.txt'.
+    classfile = $vardir/classes.txt
+
+    # Where puppetd caches the local configuration.  An
+    # extension indicating the cache format is added automatically.
+    # The default value is '$confdir/localconfig'.
+    localconfig = $vardir/localconfig
+
+[master]
+   storeconfigs = true
+   storeconfigs_backend = puppetdb
+
+   reports = store,puppetdb

--- a/examples/vagrant/puppetdb.conf
+++ b/examples/vagrant/puppetdb.conf
@@ -1,0 +1,3 @@
+[main]
+server = puppet
+port = 8081

--- a/examples/vagrant/routes.yaml
+++ b/examples/vagrant/routes.yaml
@@ -1,0 +1,5 @@
+---
+master:
+  facts:
+    terminus: puppetdb
+    cache: yaml


### PR DESCRIPTION
Swift requires storeconfigs, which is provided by PuppetDB.
This update adds PuppetDB to the master environment to enable
Swift installation.
