### PR TITLE
Remove duplicated code. Fix Neutron bug for 2013.2

### DIFF
--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -23,6 +23,7 @@ havana::storage::address::management: '172.16.33.5'
 ######## Database
 
 havana::mysql::root_password: 'spam-gak'
+havana::mysql::service_password: 'fuva-wax'
 havana::mysql::allowed_hosts: ['localhost', '127.0.0.1', '172.16.33.%']
 
 ######## RabbitMQ
@@ -33,7 +34,6 @@ havana::rabbitmq::password: 'pose-vix'
 ######## Keystone
 
 havana::keystone::admin_token: 'sosp-kyl'
-havana::keystone::sql::password: 'fuva-wax'
 havana::keystone::admin_email: 'chris.hoge@puppetlabs.com'
 havana::keystone::admin_password: 'fyby-tet'
 havana::keystone::verbose: 'True'
@@ -52,14 +52,12 @@ havana::users:
 
 ######## Glance
 
-havana::glance::sql::password: 'bo-xy-hi'
 havana::glance::password: 'na-mu-va'
 havana::glance::verbose: 'True'
 havana::glance::debug: 'True'
 
 ######## Cinder
 
-havana::cinder::sql::password: 'meto-jag'
 havana::cinder::password: 'zi-co-se'
 havana::cinder::verbose: 'True'
 havana::cinder::debug: 'True'
@@ -74,14 +72,12 @@ havana::swift::hash_suffix: 'pop-bang'
 ######## Nova
 
 havana::nova::libvirt_type: 'kvm'
-havana::nova::sql::password: 'li-hu-py'
 havana::nova::password: 'quuk-paj'
 havana::nova::verbose: 'True'
 havana::nova::debug: 'True'
 
 ######## Neutron
 
-havana::neutron::sql::password: 'spal-nyp'
 havana::neutron::password: 'whi-rtuz'
 havana::neutron::shared_secret: 'by-sa-bo'
 havana::neutron::verbose: 'True'
@@ -95,7 +91,6 @@ havana::ceilometer::verbose: 'True'
 havana::ceilometer::debug: 'True'
 
 ######## Heat
-havana::heat::sql::password: 'whi-truz'
 havana::heat::password: 'zap-bang'
 havana::heat::encryption_key: 'heatsecretkey'
 havana::heat::verbose: 'True'

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -5,4 +5,7 @@ class havana::profile::base {
 
   # all nodes need the OpenStack repository
   class { '::openstack::repo': }
+
+  # database connectors
+  class { '::havana::resources::connectors': }
 }

--- a/manifests/profile/ceilometer/api.pp
+++ b/manifests/profile/ceilometer/api.pp
@@ -1,41 +1,9 @@
 #The profile to set up the Ceilometer API
 class havana::profile::ceilometer::api {
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
+  havana::resources::controller { 'ceilometer': }
 
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
-  $controller_management_address =
-    hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  if $management_address != $controller_management_address {
-    fail("Ceilometer API/Scheduler setup failed. The inferred location the
-    nova API the havana::network::management::device hiera value is
-    ${management_address}. The explicit address
-    from havana::controller::address::management is
-    ${controller_management_address}. Please correct this difference.")
-  }
-
-  if $api_address != $controller_api_address {
-    fail("Ceilometer API/Scheduler setup failed. The inferred location the
-    Cinder API the havana::network::api::device hiera value is
-    ${api_address}. The explicit address
-    from havana::controller::address::api is ${controller_api_address}. Please
-    correct this difference.")
-  }
-
-  # public API access
-  firewall { '8777 - Ceilometer API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '8777',
+  havana::resources::firewall { 'Ceilometer API':
+    port => '8777',
   }
 
   class { '::ceilometer::keystone::auth':

--- a/manifests/profile/ceilometer/common.pp
+++ b/manifests/profile/ceilometer/common.pp
@@ -1,21 +1,8 @@
 class havana::profile::ceilometer::common (
   $is_controller = false,
 ) {
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
-
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
   $controller_management_address =
     hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  notify { "${controller_management_address}": }
 
   $mongo_password = hiera('havana::ceilometer::mongo::password')
   $mongo_connection = 

--- a/manifests/profile/cinder/api.pp
+++ b/manifests/profile/cinder/api.pp
@@ -1,59 +1,15 @@
 # The profile for installing the Cinder API
 class havana::profile::cinder::api {
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
 
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
-  $controller_management_address =
-    hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  $storage_management_address = hiera('havana::storage::address::management')
-  $storage_api_address = hiera('havana::storage::address::api')
-
-  $sql_password = hiera('havana::cinder::sql::password')
-
-  if $management_address != $controller_management_address {
-    fail("Cinder API/Scheduler setup failed. The inferred location the
-    Cinder API the havana::network::management::device hiera value is
-    ${management_address}. The explicit address
-    from havana::controller::address::management is
-    ${controller_management_address}. Please correct this difference.")
-  }
-
-  if $api_address != $controller_api_address {
-    fail("Cinder API/Scheduler setup failed. The inferred location the
-    Cinder API the havana::network::api::device hiera value is
-    ${api_address}. The explicit address
-    from havana::controller::address::api is ${controller_api_address}. Please
-    correct this difference.")
-  }
-
-  firewall { '08776 - Cinder API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '8776',
-  }
-
-  class { '::cinder::db::mysql':
-    user          => 'cinder',
-    password      => hiera('havana::cinder::sql::password'),
-    dbname        => 'cinder',
-    allowed_hosts => hiera('havana::mysql::allowed_hosts'),
-  }
+  havana::resources::controller { 'cinder': }
+  havana::resources::database { 'cinder': }
+  havana::resources::firewall { 'Cinder API': port => '8776', }
 
   class { '::cinder::keystone::auth':
     password         => hiera('havana::cinder::password'),
-    public_address   => $api_address,
-    admin_address    => $management_address,
-    internal_address => $management_address,
+    public_address   => hiera('havana::controller::address::api'),
+    admin_address    => hiera('havana::controller::address::management'),
+    internal_address => hiera('havana::controller::address::management'),
     region           => hiera('havana::region'),
   }
 

--- a/manifests/profile/cinder/common.pp
+++ b/manifests/profile/cinder/common.pp
@@ -1,29 +1,8 @@
 # common configuration for cinder profiles
 class havana::profile::cinder::common {
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
-
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
-  $controller_management_address =
-    hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  $storage_management_address = hiera('havana::storage::address::management')
-  $storage_api_address = hiera('havana::storage::address::api')
-
-  $sql_password = hiera('havana::cinder::sql::password')
-  $sql_connection =
-    "mysql://cinder:${sql_password}@${controller_management_address}/cinder"
-
   class { '::cinder':
-    sql_connection    => $sql_connection,
-    rabbit_host       => $controller_management_address,
+    sql_connection    => $::havana::resources::connectors::cinder,
+    rabbit_host       => hiera('havana::controller::address::management'),
     rabbit_userid     => hiera('havana::rabbitmq::user'),
     rabbit_password   => hiera('havana::rabbitmq::password'),
     debug             => hiera('havana::cinder::debug'),

--- a/manifests/profile/cinder/volume.pp
+++ b/manifests/profile/cinder/volume.pp
@@ -1,12 +1,7 @@
 # The profile to install the volume service
 class havana::profile::cinder::volume {
 
-  firewall { '03260 - iscsi API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '3260',
-  }
+  havana::resources::firewall { 'ISCSI API': port => '3260', }
 
   include '::havana::profile::cinder::common'
   class { '::cinder::setup_test_volume': 

--- a/manifests/profile/glance/api.pp
+++ b/manifests/profile/glance/api.pp
@@ -29,31 +29,12 @@ class havana::profile::glance::api {
     Please correct this difference.")
   }
 
-  # public API access
-  firewall { '09292 - Glance API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '9292',
-  }
-
-  # public API access
-  firewall { '09191 - Glance Registry':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '9191',
-  }
-
-  $sql_password = hiera('havana::glance::sql::password')
-  $sql_connection =
-    "mysql://glance:${sql_password}@${controller_address}/glance"
-
-  # database setup
+  havana::resources::firewall { 'Glance API': port      => '9292', }
+  havana::resources::firewall { 'Glance Registry': port => '9191', }
 
   class { '::glance::api':
     keystone_password => hiera('havana::glance::password'),
-    auth_host         => $controller_address,
+    auth_host         => hiera('havana::controller::address::management'),
     keystone_tenant   => 'services',
     keystone_user     => 'glance',
     sql_connection    => $sql_connection,
@@ -66,8 +47,8 @@ class havana::profile::glance::api {
 
   class { '::glance::registry':
     keystone_password => hiera('havana::glance::password'),
-    sql_connection    => $sql_connection,
-    auth_host         => $controller_address,
+    sql_connection    => $::havana::resources::connectors::glance,
+    auth_host         => hiera('havana::controller::address::management'),
     keystone_tenant   => 'services',
     keystone_user     => 'glance',
     verbose           => true,

--- a/manifests/profile/glance/auth.pp
+++ b/manifests/profile/glance/auth.pp
@@ -1,26 +1,13 @@
 # The profile to set up the endpoints, auth, and database for Glance
 class havana::profile::glance::auth {
-  $explicit_management_address = hiera('havana::storage::address::management')
-  $explicit_api_address = hiera('havana::storage::address::api')
-
-  $controller_address = hiera('havana::controller::address::management')
-
-  $sql_password = hiera('havana::glance::sql::password')
-  $sql_connection =
-    "mysql://glance:${sql_password}@${controller_address}/glance"
-
-  class { '::glance::db::mysql':
-    user          => 'glance',
-    password      => $sql_password,
-    dbname        => 'glance',
-    allowed_hosts => hiera('havana::mysql::allowed_hosts'),
-  }
+  havana::resources::controller { 'glance': }
+  havana::resources::database { 'glance': }
 
   class  { '::glance::keystone::auth':
     password         => hiera('havana::glance::password'),
-    public_address   => $explicit_api_address,
-    admin_address    => $explicit_management_address,
-    internal_address => $explicit_management_address,
+    public_address   => hiera('havana::storage::address::api'),
+    admin_address    => hiera('havana::storage::address::management'),
+    internal_address => hiera('havana::storage::address::management'),
     region           => hiera('havana::region'),
   }
 }

--- a/manifests/profile/heat/api.pp
+++ b/manifests/profile/heat/api.pp
@@ -1,94 +1,47 @@
 # The profile for installing the heat API
 class havana::profile::heat::api {
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
+  havana::resources::controller { 'heat': }
+  havana::resources::database { 'heat': }
+  havana::resources::firewall { 'Heat API': port     => '8004', }
+  havana::resources::firewall { 'Heat CFN API': port => '8000', }
 
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
-  $controller_management_address =
-    hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  $storage_management_address = hiera('havana::storage::address::management')
-  $storage_api_address = hiera('havana::storage::address::api')
-
-  if $management_address != $controller_management_address {
-    fail("heat API/Scheduler setup failed. The inferred location the
-    heat API the havana::network::management::device hiera value is
-    ${management_address}. The explicit address
-    from havana::controller::address::management is
-    ${controller_management_address}. Please correct this difference.")
-  }
-
-  if $api_address != $controller_api_address {
-    fail("heat API/Scheduler setup failed. The inferred location the
-    heat API the havana::network::api::device hiera value is
-    ${api_address}. The explicit address
-    from havana::controller::address::api is ${controller_api_address}. Please
-    correct this difference.")
-  }
-
-  firewall { '08004 - Heat API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '8004',
-  }
-
-  firewall { '08000 - Heat CFN API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '8000',
-  }
-
-  $sql_password = hiera('havana::heat::sql::password')
-  $sql_connection =
-    "mysql://heat:${sql_password}@${controller_management_address}/heat"
-
-  class { '::heat::db::mysql':
-    password      => $sql_password,
-    allowed_hosts => hiera('havana::mysql::allowed_hosts'),
-  }
+  $sql_password = hiera('havana::mysql::service_password')
+  $controller_management_address = hiera('havana::controller::address::management')
+  $sql_connection = "mysql://heat:${sql_password}@${controller_management_address}/heat"
 
   class { '::heat::keystone::auth':
     password         => hiera('havana::heat::password'),
-    public_address   => $api_address,
-    admin_address    => $management_address,
-    internal_address => $management_address,
+    public_address   => hiera('havana::controller::address::api'),
+    admin_address    => hiera('havana::controller::address::management'),
+    internal_address => hiera('havana::controller::address::management'),
     region           => hiera('havana::region'),
   }
 
   class { '::heat::keystone::auth_cfn': 
     password         => hiera('havana::heat::password'),
-    public_address   => $api_address,
-    admin_address    => $management_address,
-    internal_address => $management_address,
+    public_address   => hiera('havana::controller::address::api'),
+    admin_address    => hiera('havana::controller::address::management'),
+    internal_address => hiera('havana::controller::address::management'),
     region           => hiera('havana::region'),
   }
 
   class { '::heat':
     sql_connection    => $sql_connection,
-    rabbit_host       => $controller_management_address,
+    rabbit_host       => hiera('havana::controller::address::management'),
     rabbit_userid     => hiera('havana::rabbitmq::user'),
     rabbit_password   => hiera('havana::rabbitmq::password'),
     debug             => hiera('havana::cinder::debug'),
     verbose           => hiera('havana::cinder::verbose'),
-    keystone_host     => $controller_management_address,
+    keystone_host     => hiera('havana::controller::address::management'),
     keystone_password => hiera('havana::heat::password'),
   }
 
   class { '::heat::api':
-    bind_host => $api_address,
+    bind_host => hiera('havana::controller::address::api'),
   }
 
   class { '::heat::api_cfn':
-    bind_host => $api_address,
+    bind_host => hiera('havana::controller::address::api'),
   }
 
   class { '::heat::engine':

--- a/manifests/profile/keystone.pp
+++ b/manifests/profile/keystone.pp
@@ -1,53 +1,13 @@
 # The profile to install the Keystone service
 class havana::profile::keystone {
-  $api_device = hiera('havana::network::api::device')
-  $api_address = getvar("ipaddress_${api_device}")
 
-  $management_device = hiera('havana::network::management::device')
-  $management_address = getvar("ipaddress_${management_device}")
-
-  $explicit_management_address =
-    hiera('havana::controller::address::management')
-  $explicit_api_address = hiera('havana::controller::address::api')
-
-  if $management_address != $explicit_management_address {
-    fail("Keystone setup failed. The inferred location of keystone
-    from the havana::network::management::device hiera value is
-    ${management_address}. The explicit address
-    from havana::controller::address is ${explicit_management_address}.
-    Please correct this difference.")
-  }
-
-  if $api_address != $explicit_api_address {
-    fail("Keystone setup failed. The inferred location of keystone
-    from the havana::network::api::device hiera value is
-    ${api_address}. The explicit address
-    from havana::controller::address::api is ${explicit_api_address}.
-    Please correct this difference.")
-  }
-
-  firewall { '5000 - Keystone API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '5000',
-    source => hiera('havana::network::api'),
-  }
-
-  $sql_password = hiera('havana::keystone::sql::password')
-  $sql_connection =
-    "mysql://keystone:${sql_password}@${management_address}/keystone"
-
-  class { '::keystone::db::mysql':
-    user          => 'keystone',
-    password      => $sql_password,
-    dbname        => 'keystone',
-    allowed_hosts => hiera('havana::mysql::allowed_hosts'),
-  }
+  havana::resources::controller { 'keystone': }
+  havana::resources::database { 'keystone': }
+  havana::resources::firewall { 'Keystone API': port => '5000', }
 
   class { '::keystone':
     admin_token    => hiera('havana::keystone::admin_token'),
-    sql_connection => $sql_connection,
+    sql_connection => $::havana::resources::connectors::keystone,
     verbose        => hiera('havana::keystone::verbose'),
     debug          => hiera('havana::keystone::debug'),
   }
@@ -59,12 +19,11 @@ class havana::profile::keystone {
   }
 
   class { 'keystone::endpoint':
-    public_address   => $api_address,
-    admin_address    => $management_address,
-    internal_address => $management_address,
+    public_address   => hiera('havana::controller::address::api'),
+    admin_address    => hiera('havana::controller::address::management'),
+    internal_address => hiera('havana::controller::address::management'),
     region           => hiera('havana::region'),
   }
-
 
   $tenants = hiera('havana::tenants')
   $users = hiera('havana::users')

--- a/manifests/profile/neutron/common.pp
+++ b/manifests/profile/neutron/common.pp
@@ -2,20 +2,13 @@
 # Flags install individual services as needed
 # This follows the suggest deployment from the neutron Administrator Guide.
 class havana::profile::neutron::common {
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
-
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
 
   $controller_management_address = hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
 
-  $sql_password = hiera('havana::neutron::sql::password')
+  $data_device = hiera('havana::network::data::device')
+  $data_address = getvar("ipaddress_${data_device}")
+
+  $sql_password = hiera('havana::mysql::service_password')
   $sql_connection =
     "mysql://neutron:${sql_password}@${controller_management_address}/neutron"
 
@@ -32,6 +25,7 @@ class havana::profile::neutron::common {
     enable_tunneling => 'True',
     local_ip         => $data_address,
     enabled          => true,
+    tunnel_types     => ['gre',],
   }
 
   # everyone gets an ovs plugin (TODO true?)

--- a/manifests/profile/neutron/server.pp
+++ b/manifests/profile/neutron/server.pp
@@ -1,58 +1,15 @@
 # The profile to set up the neutron server
 class havana::profile::neutron::server {
-
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
-
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
-  $controller_management_address = hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  # public API access
-  firewall { '9696 - neutron API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '9696',
-  }
-
-  # This class does not impact the neutron.conf file
-  class { '::neutron::db::mysql':
-    user          => 'neutron',
-    password      => hiera('havana::neutron::sql::password'),
-    dbname        => 'neutron',
-    allowed_hosts => hiera('havana::mysql::allowed_hosts'),
-  }
+  havana::resources::controller { 'neutron': }
+  havana::resources::database { 'neutron': }
+  havana::resources::firewall { 'Neutron API': port => '9696', }
 
   class { '::neutron::keystone::auth':
     password         => hiera('havana::neutron::password'),
-    public_address   => $api_address,
-    admin_address    => $management_address,
-    internal_address => $management_address,
+    public_address   => hiera('havana::controller::address::api'),
+    admin_address    => hiera('havana::controller::address::management'),
+    internal_address => hiera('havana::controller::address::management'),
     region           => hiera('havana::region'),
-  }
-
-  # Error check the addresses
-  if $management_address != $controller_management_address {
-    fail("neutron API/Scheduler setup failed. The inferred location the
-    neutron API the havana::network::management::device hiera value is
-    ${management_address}. The explicit address
-    from havana::controller::address::management is
-    ${controller_management_address}. Please correct this difference.")
-  }
-
-  if $api_address != $controller_api_address {
-    fail("neutron API/Scheduler setup failed. The inferred location the
-    neutron API the havana::network::api::device hiera value is
-    ${api_address}. The explicit address
-    from havana::controller::address::api is ${controller_api_address}. 
-    Please correct this difference.")
   }
 
   class { '::neutron::server':

--- a/manifests/profile/nova/api.pp
+++ b/manifests/profile/nova/api.pp
@@ -1,69 +1,17 @@
 # The profile to set up the Nova controller (several services)
 class havana::profile::nova::api {
-  $api_device = hiera('havana::network::api::device')
-  $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
+  havana::resources::controller { 'nova': }
+  havana::resources::database { 'nova': }
+  havana::resources::firewall { 'Nova API': port => '8774', }
+  havana::resources::firewall { 'Nova Metadata': port => '8775', }
+  havana::resources::firewall { 'Nova NoVncProxy': port => '6080', }
 
-  $api_address = getvar("ipaddress_${api_device}")
-  $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
-  $controller_management_address =
-    hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  if $management_address != $controller_management_address {
-    fail("Nova API/Scheduler setup failed. The inferred location the
-    nova API the havana::network::management::device hiera value is
-    ${management_address}. The explicit address
-    from havana::controller::address::management is
-    ${controller_management_address}. Please correct this difference.")
-  }
-
-  if $api_address != $controller_api_address {
-    fail("Nova API/Scheduler setup failed. The inferred location the
-    Cinder API the havana::network::api::device hiera value is
-    ${api_address}. The explicit address
-    from havana::controller::address::api is ${controller_api_address}. Please
-    correct this difference.")
-  }
-
-  # public API access
-  firewall { '8774 - Nova API':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '8774',
-  }
-
-  firewall { '8775 - Nova Metadata':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '8775',
-  }
-
-  firewall { '6080 - Nova NoVncProxy':
-    proto  => 'tcp',
-    state  => ['NEW'],
-    action => 'accept',
-    port   => '6080',
-  }
-
-  class { '::nova::db::mysql':
-    user          => 'nova',
-    password      => hiera('havana::nova::sql::password'),
-    dbname        => 'nova',
-    allowed_hosts => hiera('havana::mysql::allowed_hosts'),
-  }
 
   class { '::nova::keystone::auth':
     password         => hiera('havana::nova::password'),
-    public_address   => $api_address,
-    admin_address    => $management_address,
-    internal_address => $management_address,
+    public_address   => hiera('havana::controller::address::api'),
+    admin_address    => hiera('havana::controller::address::management'),
+    internal_address => hiera('havana::controller::address::management'),
     region           => hiera('havana::region'),
     cinder           => true,
   }

--- a/manifests/profile/nova/compute.pp
+++ b/manifests/profile/nova/compute.pp
@@ -1,21 +1,7 @@
 # The puppet module to set up a Nova Compute node
 class havana::profile::nova::compute {
-
-  $controller_address = hiera('havana::controller::address::management')
-  $storage_address = hiera('havana::storage::address::management')
-
-  $api_device = hiera('havana::network::api::device')
-  $api_address = getvar("ipaddress_${api_device}")
-
   $management_device = hiera('havana::network::management::device')
   $management_address = getvar("ipaddress_${management_device}")
-
-
-  $data_device = hiera('havana::network::data::device')
-  $data_address = getvar("ipaddress_${data_device}")
-
-  $sql_password = hiera('havana::nova::sql::password')
-  $sql_connection = "mysql://nova:${sql_password}@${management_address}/nova"
 
   class { 'havana::profile::nova::common':
     is_compute => true,

--- a/manifests/profile/swift/storage.pp
+++ b/manifests/profile/swift/storage.pp
@@ -2,22 +2,8 @@
 class havana::profile::swift::storage (
   $zone = undef,
 ) {
-  $api_device = hiera('havana::network::api::device')
   $management_device = hiera('havana::network::management::device')
-  $data_device = hiera('havana::network::data::device')
-  $external_device = hiera('havana::network::external::device')
-
-  $api_address = getvar("ipaddress_${api_device}")
   $management_address = getvar("ipaddress_${management_device}")
-  $data_address = getvar("ipaddress_${data_device}")
-  $external_address = getvar("ipaddress_${external_device}")
-
-  $controller_management_address =
-    hiera('havana::controller::address::management')
-  $controller_api_address = hiera('havana::controller::address::api')
-
-  $storage_management_address = hiera('havana::storage::address::management')
-  $storage_api_address = hiera('havana::storage::address::api')
 
   firewall { '6000 - Swift Object Store':
     proto  => 'tcp',
@@ -73,6 +59,6 @@ class havana::profile::swift::storage (
   }
 
   swift::ringsync { ['account','container','object']: 
-    ring_server => $controller_management_address, 
+    ring_server => hiera('havana::controller::address::management'), 
   }
 }

--- a/manifests/resources/connectors.pp
+++ b/manifests/resources/connectors.pp
@@ -1,0 +1,12 @@
+class havana::resources::connectors {
+
+  $management_address = hiera('havana::controller::address::management')
+  $password = hiera('havana::mysql::service_password')
+
+  $keystone = "mysql://keystone:${password}@${management_address}/keystone"
+  $cinder   = "mysql://cinder:${password}@${management_address}/cinder"
+  $glance   = "mysql://glance:${password}@${management_address}/glance"
+  $nova     = "mysql://nova:${password}@${management_address}/nova"
+  $neutron  = "mysql://neutron:${password}@${management_address}/neutron"
+  $heat     = "mysql://heat:${password}@${management_address}/heat"
+}

--- a/manifests/resources/controller.pp
+++ b/manifests/resources/controller.pp
@@ -1,0 +1,29 @@
+# A basic defined resource that only checks for controller
+# configuration consistency with the Hiera data
+define havana::resources::controller () {
+  $api_device = hiera('havana::network::api::device')
+  $api_address = getvar("ipaddress_${api_device}")
+
+  $management_device = hiera('havana::network::management::device')
+  $management_address = getvar("ipaddress_${management_device}")
+
+  $explicit_management_address =
+    hiera('havana::controller::address::management')
+  $explicit_api_address = hiera('havana::controller::address::api')
+
+  if $management_address != $explicit_management_address {
+    fail("${title} setup failed. The inferred location of ${title}
+    from the havana::network::management::device hiera value is
+    ${management_address}. The explicit address
+    from havana::controller::address is ${explicit_management_address}.
+    Please correct this difference.")
+  }
+
+  if $api_address != $explicit_api_address {
+    fail("${title} setup failed. The inferred location of ${title}
+    from the havana::network::api::device hiera value is
+    ${api_address}. The explicit address
+    from havana::controller::address::api is ${explicit_api_address}.
+    Please correct this difference.")
+  }
+}

--- a/manifests/resources/database.pp
+++ b/manifests/resources/database.pp
@@ -1,0 +1,8 @@
+define havana::resources::database () {
+  class { "::${title}::db::mysql":
+    user          => $title,
+    password      => hiera("havana::mysql::service_password"),
+    dbname        => $title,
+    allowed_hosts => hiera('havana::mysql::allowed_hosts'),
+  }
+}

--- a/manifests/resources/firewall.pp
+++ b/manifests/resources/firewall.pp
@@ -1,0 +1,8 @@
+define havana::resources::firewall ( $port ) {
+  firewall { "${port} - ${title}":
+    proto  => 'tcp',
+    state  => ['NEW'],
+    action => 'accept',
+    port   => $port,
+  }
+}


### PR DESCRIPTION
Removed a significant amount of duplicated code related to
setting up controller services, firewalls, and database settings.

Fixed a bug introduced into the module with the Havana 2013.2
release.
