### PR TITLE
Added support for all-in-one deployments

### DIFF
--- a/examples/allinone.yaml
+++ b/examples/allinone.yaml
@@ -10,8 +10,8 @@ havana::network::data: '172.16.44.0/24'
 
 havana::controller::address::api: '192.168.11.4'
 havana::controller::address::management: '172.16.33.4'
-havana::storage::address::api: '192.168.11.5'
-havana::storage::address::management: '172.16.33.5'
+havana::storage::address::api: '192.168.11.4'
+havana::storage::address::management: '172.16.33.4'
 
 ######## Database
 

--- a/lib/puppet/parser/functions/device_for_network.rb
+++ b/lib/puppet/parser/functions/device_for_network.rb
@@ -1,0 +1,30 @@
+require "ipaddr"
+
+module Puppet::Parser::Functions
+
+  newfunction(:device_for_network, :type => :rvalue, :doc => <<-EOS
+Returns the device for the given network in cidr notation
+
+device_for_network("127.0.0.0/24") => lo0
+    EOS
+  ) do |args| 
+    devices_in_range = [] 
+
+    range = IPAddr.new(args[0])
+    facts = compiler.node.facts.values
+    ip_addresses = facts.select { |key, value| key.match /^ipaddress_(.*)/ }
+
+    ip_addresses.each do |pair|
+      key = pair[0]
+      string_address = pair[1]
+      ip_address = IPAddr.new(string_address)
+      if range.include?(ip_address)
+        devices_in_range.push(key.gsub(/^ipaddress_/,""))
+      end
+    end
+
+    # TODO don't be a dork dork with the return
+    # handle multiple values!
+    return devices_in_range.first
+  end
+end

--- a/lib/puppet/parser/functions/ip_for_network.rb
+++ b/lib/puppet/parser/functions/ip_for_network.rb
@@ -1,0 +1,30 @@
+require "ipaddr"
+
+module Puppet::Parser::Functions
+
+  newfunction(:ip_for_network, :type => :rvalue, :doc => <<-EOS
+Returns an ip address for the given network in cidr notation
+
+ip_for_network("127.0.0.0/24") => 127.0.0.1
+    EOS
+  ) do |args| 
+    addresses_in_range = [] 
+
+    range = IPAddr.new(args[0])
+    facts = compiler.node.facts.values
+    ip_addresses = facts.select { |key, value| key.match /^ipaddress/ }
+
+    ip_addresses.each do |pair|
+      key = pair[0]
+      string_address = pair[1]
+      ip_address = IPAddr.new(string_address)
+      if range.include?(ip_address)
+        addresses_in_range.push(string_address)
+      end
+    end
+
+    # TODO don't be a dork dork with the return
+    # handle multiple values!
+    return addresses_in_range.first
+  end
+end

--- a/manifests/common/ceilometer.pp
+++ b/manifests/common/ceilometer.pp
@@ -1,8 +1,9 @@
-class havana::profile::ceilometer::common (
-  $is_controller = false,
-) {
-  $controller_management_address =
-    hiera('havana::controller::address::management')
+# Common class for ceilometer installation
+# Private, and should not be used on its own
+class havana::common::ceilometer {
+  $is_controller = $::havana::profile::base::is_controller
+
+  $controller_management_address = hiera('havana::controller::address::management')
 
   $mongo_password = hiera('havana::ceilometer::mongo::password')
   $mongo_connection = 
@@ -10,8 +11,8 @@ class havana::profile::ceilometer::common (
 
   class { '::ceilometer':
     metering_secret => hiera('havana::ceilometer::meteringsecret'),
-    debug           => hiera('havana::ceilometer::debug'),
-    verbose         => hiera('havana::ceilometer::verbose'),
+    debug           => hiera('havana::debug'),
+    verbose         => hiera('havana::verbose'),
     rabbit_hosts    => [$controller_management_address],
     rabbit_userid   => hiera('havana::rabbitmq::user'),
     rabbit_password => hiera('havana::rabbitmq::password'),

--- a/manifests/common/cinder.pp
+++ b/manifests/common/cinder.pp
@@ -1,11 +1,12 @@
-# common configuration for cinder profiles
-class havana::profile::cinder::common {
+# Common class for cinder installation
+# Private, and should not be used on its own
+class havana::common::cinder {
   class { '::cinder':
     sql_connection    => $::havana::resources::connectors::cinder,
     rabbit_host       => hiera('havana::controller::address::management'),
     rabbit_userid     => hiera('havana::rabbitmq::user'),
     rabbit_password   => hiera('havana::rabbitmq::password'),
-    debug             => hiera('havana::cinder::debug'),
-    verbose           => hiera('havana::cinder::verbose'),
+    debug             => hiera('havana::debug'),
+    verbose           => hiera('havana::verbose'),
   }
 }

--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -1,19 +1,20 @@
+# Common class for neutron installation
+# Private, and should not be used on its own
 # Sets up configuration common to all neutron nodes.
 # Flags install individual services as needed
 # This follows the suggest deployment from the neutron Administrator Guide.
-class havana::profile::neutron::common {
-
+class havana::common::neutron {
   $controller_management_address = hiera('havana::controller::address::management')
 
-  $data_device = hiera('havana::network::data::device')
-  $data_address = getvar("ipaddress_${data_device}")
+  $data_network = hiera('havana::network::data')
+  $data_address = ip_for_network($data_network)
 
   class { '::neutron':
     rabbit_host        => $controller_management_address,
     rabbit_user        => hiera('havana::rabbitmq::user'),
     rabbit_password    => hiera('havana::rabbitmq::password'),
-    debug              => hiera('havana::neutron::debug'),
-    verbose            => hiera('havana::neutron::verbose'),
+    debug              => hiera('havana::debug'),
+    verbose            => hiera('havana::verbose'),
   }
 
   # everone gets an ovs agent (TODO true?)

--- a/manifests/common/nova.pp
+++ b/manifests/common/nova.pp
@@ -1,13 +1,15 @@
-# common configuration for the nova services
-class havana::profile::nova::common (
-  $is_controller = false,
-  $is_compute    = false,
-) {
-  $management_device = hiera('havana::network::management::device')
-  $management_address = getvar("ipaddress_${management_device}")
+# Common class for nova installation
+# Private, and should not be used on its own
+# usage: include from controller, declare from worker
+# This is to handle dependency
+# depends on havana::profile::base having been added to a node
+class havana::common::nova ($is_compute    = false) {
+  $is_controller = $::havana::profile::base::is_controller
+
+  $management_network = hiera('havana::network::management')
+  $management_address = ip_for_network($management_network)
 
   $storage_management_address = hiera('havana::storage::address::management')
-
   $controller_management_address = hiera('havana::controller::address::management')
 
   class { '::nova':
@@ -17,8 +19,8 @@ class havana::profile::nova::common (
     rabbit_hosts       => [$controller_management_address],
     rabbit_userid      => hiera('havana::rabbitmq::user'),
     rabbit_password    => hiera('havana::rabbitmq::password'),
-    debug              => hiera('havana::nova::debug'),
-    verbose            => hiera('havana::nova::verbose'),
+    debug              => hiera('havana::debug'),
+    verbose            => hiera('havana::verbose'),
   }
 
   class { '::nova::api':

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -8,4 +8,24 @@ class havana::profile::base {
 
   # database connectors
   class { '::havana::resources::connectors': }
+
+  $management_network = hiera('havana::network::management')
+  $management_address = ip_for_network($management_network)
+  $controller_management_address = hiera('havana::controller::address::management')
+
+  $management_matches = ($management_address == $controller_management_address)
+
+  $api_network = hiera('havana::network::api')
+  $api_address = ip_for_network($api_network)
+  $controller_api_address = hiera('havana::controller::address::api')
+
+  $api_matches = ($api_address == $controller_api_address)
+
+  $is_controller = ($management_matches and $api_matches)
+
+  if $is_controller {
+    notify { "This node is a controller node. ${management_address} == ${controller_management_address} and ${api_address} == ${controller_api_address}": }
+  } else {
+    notify { "This node is not a controller node. ${management_address} != ${controller_management_address} or ${api_address} != ${controller_api_address}": }
+  }
 }

--- a/manifests/profile/ceilometer/agent.pp
+++ b/manifests/profile/ceilometer/agent.pp
@@ -1,8 +1,4 @@
 class havana::profile::ceilometer::agent {
-  class { '::havana::profile::ceilometer::common':
-    is_controller => false,
-  } ->
-
-  class { '::ceilometer::agent::compute':
-  }
+  class { '::havana::common::ceilometer': } ->
+  class { '::ceilometer::agent::compute': }
 }

--- a/manifests/profile/ceilometer/api.pp
+++ b/manifests/profile/ceilometer/api.pp
@@ -1,4 +1,6 @@
-#The profile to set up the Ceilometer API
+# The profile to set up the Ceilometer API
+# For co-located api and worker nodes this appear
+# after havana::profile::ceilometer::agent
 class havana::profile::ceilometer::api {
   havana::resources::controller { 'ceilometer': }
 
@@ -8,9 +10,9 @@ class havana::profile::ceilometer::api {
 
   class { '::ceilometer::keystone::auth':
     password         => hiera('havana::ceilometer::password'),
-    public_address   => $api_address,
-    admin_address    => $management_address,
-    internal_address => $management_address,
+    public_address   => hiera('havana::controller::address::api'),
+    admin_address    => hiera('havana::controller::address::management'),
+    internal_address => hiera('havana::controller::address::management'),
     region           => hiera('havana::region'),
   }
 
@@ -35,9 +37,7 @@ class havana::profile::ceilometer::api {
 
   class { '::ceilometer::collector': }
 
-  class { '::havana::profile::ceilometer::common':
-    is_controller => true,
-  }
+  include ::havana::common::ceilometer
 
   mongodb_database { 'ceilometer':
     ensure  => present,

--- a/manifests/profile/cinder/api.pp
+++ b/manifests/profile/cinder/api.pp
@@ -13,7 +13,7 @@ class havana::profile::cinder::api {
     region           => hiera('havana::region'),
   }
 
-  include '::havana::profile::cinder::common'
+  include ::havana::common::cinder
 
   class { '::cinder::api':
     keystone_password  => hiera('havana::cinder::password'),

--- a/manifests/profile/cinder/volume.pp
+++ b/manifests/profile/cinder/volume.pp
@@ -3,7 +3,8 @@ class havana::profile::cinder::volume {
 
   havana::resources::firewall { 'ISCSI API': port => '3260', }
 
-  include '::havana::profile::cinder::common'
+  include ::havana::common::cinder
+
   class { '::cinder::setup_test_volume': 
     volume_name => 'cinder-volumes',
     size        => hiera('havana::cinder::volume_size')

--- a/manifests/profile/glance/api.pp
+++ b/manifests/profile/glance/api.pp
@@ -2,11 +2,11 @@
 # Note that for this configuration API controls the storage,
 # so it is on the storage node instead of the control node
 class havana::profile::glance::api {
-  $api_device = hiera('havana::network::api::device')
-  $api_address = getvar("ipaddress_${api_device}")
+  $api_network = hiera('havana::network::api')
+  $api_address = ip_for_network($api_network)
 
-  $management_device = hiera('havana::network::management::device')
-  $management_address = getvar("ipaddress_${management_device}")
+  $management_network = hiera('havana::network::management')
+  $management_address = ip_for_network($management_network)
 
   $explicit_management_address = hiera('havana::storage::address::management')
   $explicit_api_address = hiera('havana::storage::address::api')
@@ -15,7 +15,7 @@ class havana::profile::glance::api {
 
   if $management_address != $explicit_management_address {
     fail("Glance Auth setup failed. The inferred location of Glance from
-    the havana::network::management::device hiera value i
+    the havana::network::management hiera value is
     ${management_address}. The explicit address from
     havana::storage::address::management is ${explicit_management_address}.
     Please correct this difference.")
@@ -23,7 +23,7 @@ class havana::profile::glance::api {
 
   if $api_address != $explicit_api_address {
     fail("Glance Auth setup failed. The inferred location of Glance from
-    the havana::network::management::device hiera value is
+    the havana::network::management hiera value is
     ${api_address}. The explicit address from
     havana::storage::address::api is ${explicit_api_address}.
     Please correct this difference.")
@@ -39,8 +39,8 @@ class havana::profile::glance::api {
     keystone_user     => 'glance',
     sql_connection    => $::havana::resources::connectors::glance,
     registry_host     => hiera('havana::storage::address::management'),
-    verbose           => hiera('havana::glance::verbose'),
-    debug             => hiera('havana::glance::debug'),
+    verbose           => hiera('havana::verbose'),
+    debug             => hiera('havana::debug'),
   }
 
   class { '::glance::backend::file': }
@@ -51,8 +51,8 @@ class havana::profile::glance::api {
     auth_host         => hiera('havana::controller::address::management'),
     keystone_tenant   => 'services',
     keystone_user     => 'glance',
-    verbose           => true,
-    debug             => true,
+    verbose           => hiera('havana::verbose'),
+    debug             => hiera('havana::debug'),
   }
 
   class { '::glance::notify::rabbitmq': 

--- a/manifests/profile/heat/api.pp
+++ b/manifests/profile/heat/api.pp
@@ -28,8 +28,8 @@ class havana::profile::heat::api {
     rabbit_host       => hiera('havana::controller::address::management'),
     rabbit_userid     => hiera('havana::rabbitmq::user'),
     rabbit_password   => hiera('havana::rabbitmq::password'),
-    debug             => hiera('havana::cinder::debug'),
-    verbose           => hiera('havana::cinder::verbose'),
+    debug             => hiera('havana::debug'),
+    verbose           => hiera('havana::verbose'),
     keystone_host     => hiera('havana::controller::address::management'),
     keystone_password => hiera('havana::heat::password'),
   }

--- a/manifests/profile/keystone.pp
+++ b/manifests/profile/keystone.pp
@@ -8,8 +8,8 @@ class havana::profile::keystone {
   class { '::keystone':
     admin_token    => hiera('havana::keystone::admin_token'),
     sql_connection => $::havana::resources::connectors::keystone,
-    verbose        => hiera('havana::keystone::verbose'),
-    debug          => hiera('havana::keystone::debug'),
+    verbose        => hiera('havana::verbose'),
+    debug          => hiera('havana::debug'),
   }
 
   class { '::keystone::roles::admin':

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -1,12 +1,12 @@
 # The profile to install an OpenStack specific MongoDB server
 class havana::profile::mongodb {
-  $management_device = hiera('havana::network::management::device')
-  $inferred_address = getvar("ipaddress_${management_device}")
+  $management_network = hiera('havana::network::management')
+  $inferred_address = ip_for_network($management_network)
   $explicit_address = hiera('havana::controller::address::management')
 
   if $inferred_address != $explicit_address {
     fail("MongoDB setup failed. The inferred location of the database based on the
-    havana::network::management::device hiera value is ${inferred_address}. The
+    havana::network::management hiera value is ${inferred_address}. The
     explicit address from havana::controller::address::management
     is ${explicit_address}. Please correct this difference.")
   }

--- a/manifests/profile/mysql.pp
+++ b/manifests/profile/mysql.pp
@@ -1,13 +1,13 @@
 # The profile to install an OpenStack specific mysql server
 class havana::profile::mysql {
 
-  $management_device = hiera('havana::network::management::device')
-  $inferred_address = getvar("ipaddress_${management_device}")
+  $management_network = hiera('havana::network::management')
+  $inferred_address = ip_for_network($management_network)
   $explicit_address = hiera('havana::controller::address::management')
 
   if $inferred_address != $explicit_address {
     fail("MySQL setup failed. The inferred location of the database based on the
-    havana::network::management::device hiera value is ${inferred_address}. The
+    havana::network::management hiera value is ${inferred_address}. The
     explicit address from havana::controller::address::management
     is ${explicit_address}. Please correct this difference.")
   }

--- a/manifests/profile/neutron/agent.pp
+++ b/manifests/profile/neutron/agent.pp
@@ -1,4 +1,4 @@
 # The profile to set up a neutron agent
 class havana::profile::neutron::agent {
-  include 'havana::profile::neutron::common'
+  include ::havana::common::neutron
 }

--- a/manifests/profile/neutron/router.pp
+++ b/manifests/profile/neutron/router.pp
@@ -10,16 +10,16 @@ class havana::profile::neutron::router {
   }
 
   $controller_management_address = hiera('havana::controller::address::management')
-  include 'havana::profile::neutron::common'
+  include ::havana::common::neutron
 
   ### Router service installation
   class { '::neutron::agents::l3':
-    debug   => hiera('havana::neutron::debug'),
+    debug   => hiera('havana::debug'),
     enabled => true,
   }
 
   class { '::neutron::agents::dhcp':
-    debug   => hiera('havana::neutron::debug'),
+    debug   => hiera('havana::debug'),
     enabled => true,
   }
 
@@ -27,7 +27,7 @@ class havana::profile::neutron::router {
     auth_password => hiera('havana::neutron::password'),
     shared_secret => hiera('havana::neutron::shared_secret'),
     auth_url      => "http://${controller_management_address}:35357/v2.0",
-    debug         => hiera('havana::neutron::debug'),
+    debug         => hiera('havana::debug'),
     auth_region   => hiera('havana::region'),
     metadata_ip   => $controller_management_address,
     enabled       => true,
@@ -48,7 +48,8 @@ class havana::profile::neutron::router {
     ensure => present,
   }
 
-  $external_device = hiera('havana::network::external::device')
+  $external_network = hiera('havana::network::external')
+  $external_device = device_for_network($external_network)
 
   vs_port { $external_device:
     ensure  => present,

--- a/manifests/profile/neutron/server.pp
+++ b/manifests/profile/neutron/server.pp
@@ -18,5 +18,5 @@ class havana::profile::neutron::server {
     enabled       => true,
   }
 
-  include 'havana::profile::neutron::common'
+  include ::havana::common::neutron
 }

--- a/manifests/profile/nova/api.pp
+++ b/manifests/profile/nova/api.pp
@@ -6,7 +6,6 @@ class havana::profile::nova::api {
   havana::resources::firewall { 'Nova Metadata': port => '8775', }
   havana::resources::firewall { 'Nova NoVncProxy': port => '6080', }
 
-
   class { '::nova::keystone::auth':
     password         => hiera('havana::nova::password'),
     public_address   => hiera('havana::controller::address::api'),
@@ -16,8 +15,6 @@ class havana::profile::nova::api {
     cinder           => true,
   }
 
-  class { 'havana::profile::nova::common':
-    is_controller => true,
-  }
+  include ::havana::common::nova
 }
 

--- a/manifests/profile/nova/compute.pp
+++ b/manifests/profile/nova/compute.pp
@@ -1,9 +1,9 @@
 # The puppet module to set up a Nova Compute node
 class havana::profile::nova::compute {
-  $management_device = hiera('havana::network::management::device')
-  $management_address = getvar("ipaddress_${management_device}")
+  $management_network = hiera('havana::network::management')
+  $management_address = ip_for_network($management_network)
 
-  class { 'havana::profile::nova::common':
+  class { 'havana::common::nova':
     is_compute => true,
   }
 

--- a/manifests/profile/swift/storage.pp
+++ b/manifests/profile/swift/storage.pp
@@ -2,8 +2,8 @@
 class havana::profile::swift::storage (
   $zone = undef,
 ) {
-  $management_device = hiera('havana::network::management::device')
-  $management_address = getvar("ipaddress_${management_device}")
+  $management_network = hiera('havana::network::management')
+  $management_address = ip_for_network($management_network)
 
   firewall { '6000 - Swift Object Store':
     proto  => 'tcp',

--- a/manifests/resources/controller.pp
+++ b/manifests/resources/controller.pp
@@ -1,29 +1,18 @@
 # A basic defined resource that only checks for controller
 # configuration consistency with the Hiera data
 define havana::resources::controller () {
-  $api_device = hiera('havana::network::api::device')
-  $api_address = getvar("ipaddress_${api_device}")
+  $api_address = hiera('havana::controller::address::api')
+  $management_address = hiera('havana::controller::address::management')
 
-  $management_device = hiera('havana::network::management::device')
-  $management_address = getvar("ipaddress_${management_device}")
-
-  $explicit_management_address =
-    hiera('havana::controller::address::management')
-  $explicit_api_address = hiera('havana::controller::address::api')
-
-  if $management_address != $explicit_management_address {
-    fail("${title} setup failed. The inferred location of ${title}
-    from the havana::network::management::device hiera value is
-    ${management_address}. The explicit address
-    from havana::controller::address is ${explicit_management_address}.
-    Please correct this difference.")
+  unless has_ip_address($api_address) {
+    fail("${title} setup failed. This node is listed
+    as a controller, but does not have the api ip address
+    ${api_address}.")
   }
 
-  if $api_address != $explicit_api_address {
-    fail("${title} setup failed. The inferred location of ${title}
-    from the havana::network::api::device hiera value is
-    ${api_address}. The explicit address
-    from havana::controller::address::api is ${explicit_api_address}.
-    Please correct this difference.")
+  unless has_ip_address($management_address) {
+    fail("${title} setup failed. This node is listed
+    as a controller, but does not have the management ip address
+    ${management_address}.")
   }
 }

--- a/manifests/role/allinone.pp
+++ b/manifests/role/allinone.pp
@@ -1,0 +1,21 @@
+class havana::role::allinone inherits ::havana::role {
+  class { '::havana::profile::firewall': }
+  class { '::havana::profile::rabbitmq': }
+  class { '::havana::profile::memcache': }
+  class { '::havana::profile::mysql': }
+  class { '::havana::profile::mongodb': }
+  class { '::havana::profile::keystone': } 
+  class { '::havana::profile::ceilometer::agent': }
+  class { '::havana::profile::ceilometer::api': }
+  class { '::havana::profile::glance::api': }
+  class { '::havana::profile::glance::auth': }
+  class { '::havana::profile::cinder::volume': }
+  class { '::havana::profile::cinder::api': }
+  class { '::havana::profile::nova::compute': }
+  class { '::havana::profile::nova::api': }
+  class { '::havana::profile::neutron::router': }
+  class { '::havana::profile::neutron::server': }
+  class { '::havana::profile::heat::api': }
+  class { '::havana::profile::horizon': }
+  class { '::havana::profile::auth_file': }
+}


### PR DESCRIPTION
Refactored code to allow for all-in-one deployments. Moved
common code out of profile directory to make profiles truer to
their intention as composition classes. Added function to
determine ip addresses based on network ranges to remove
explicit dependency on fixed devices. Added function to
determing device based on network ranges to set up
neutron properly. Refactored logging flags so verbosity and
debugging levels are all controlled by two global hiera
parameters.
