### PR TITLE
Add librarian-puppet support

### DIFF
--- a/examples/allinone/00_package.sh
+++ b/examples/allinone/00_package.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# This script is used for development. It packages up the working
-# puppetlabs-havana development directory.
-rm *gz
-cd puppetlabs-havana
-rm pkg/*gz
-puppet module build
-cp pkg/*gz ../.
-cd ..

--- a/examples/allinone/10_setup_master.sh
+++ b/examples/allinone/10_setup_master.sh
@@ -2,12 +2,14 @@
 # Set up the Puppet Master
 
 vagrant ssh puppet -c "sudo service iptables stop; \
-sudo puppet module install puppetlabs/puppetdb; \
-sudo puppet module install puppetlabs/ntp; \
-sudo puppet module install puppetlabs/mysql --version 0.6.1; \
-sudo puppet module install puppetlabs/openstack; \
-sudo puppet module install puppetlabs/mongodb; \
-sudo cp /vagrant/site.pp /etc/puppet/manifests/site.pp; \
-sudo chown root:puppet /etc/puppet/manifests/site.pp; \
+sudo rpm -i http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm; \
+sudo yum install -y puppet-server; \
+sudo yum install -y git; \
+sudo rmdir /etc/puppet/modules || sudo unlink /etc/puppet/modules; \
+sudo ln -s /vagrant/modules /etc/puppet/modules; \
+sudo ln -s /vagrant/site.pp /etc/puppet/manifests/site.pp; \
+sudo gem install librarian-puppet --no-ri --no-rdoc; \
+cd /vagrant; \
+sudo librarian-puppet install --verbose --path /vagrant/modules; \
 sudo service puppetmaster start;\
 sudo puppet agent -t;"

--- a/examples/allinone/11_setup_havana.sh
+++ b/examples/allinone/11_setup_havana.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
-# Move the Havana module to the Puppet Master
-vagrant ssh puppet -c "cd /etc/puppet/modules; \
-sudo tar -xvzf /vagrant/*gz; \
-sudo rm -rf havana
-sudo mv puppetlabs-havana* havana; \
-sudo cp /vagrant/hiera.yaml /etc/puppet/hiera.yaml; \
-sudo chown root:puppet /etc/puppet/hiera.yaml; \
-sudo mkdir /etc/puppet/hieradata; \
-sudo chown root:puppet /etc/puppet/hieradata; \
-sudo cp /etc/puppet/modules/havana/examples/allinone.yaml /etc/puppet/hieradata/common.yaml; \
-sudo chown root:puppet /etc/puppet/hieradata/common.yaml; \
+# Mount the Havana module on the Puppet Master
+vagrant ssh puppet -c "sudo ln -s /havana /etc/puppet/modules; \
+sudo ln -s /havana/examples/hiera.yaml /etc/puppet/hiera.yaml; \
+sudo mkdir -p /etc/puppet/hieradata; \
+sudo ln -s /havana/examples/allinone.yaml /etc/puppet/hieradata/common.yaml; \
 sudo service puppetmaster restart;"

--- a/examples/allinone/Puppetfile
+++ b/examples/allinone/Puppetfile
@@ -1,0 +1,9 @@
+forge "http://forge.puppetlabs.com"
+
+mod "puppetlabs/puppetdb"
+mod "puppetlabs/ntp"
+mod "puppetlabs/openstack"
+mod "puppetlabs/mysql", "0.6.1"
+mod "puppetlabs/mongodb"
+
+# vim:ft=ruby

--- a/examples/allinone/Vagrantfile
+++ b/examples/allinone/Vagrantfile
@@ -21,6 +21,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     puppet.vm.hostname = "puppet"
 
+    puppet.vm.synced_folder "../../", "/havana"
+
     puppet.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "1024"
     end

--- a/examples/allinone/firstrun.sh
+++ b/examples/allinone/firstrun.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-./00_package.sh
 ./05_up.sh
 ./10_setup_master.sh
 ./11_setup_havana.sh

--- a/examples/allinone/hiera.yaml
+++ b/examples/allinone/hiera.yaml
@@ -1,7 +1,0 @@
----
-:backends:
-  - yaml
-:yaml:
-  :datadir: /etc/puppet/hieradata
-:hierarchy:
-  - common

--- a/examples/allinone/redeploy.sh
+++ b/examples/allinone/redeploy.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-./00_package.sh
 ./11_setup_havana.sh

--- a/examples/vagrant/00_package.sh
+++ b/examples/vagrant/00_package.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# This script is used for development. It packages up the working
-# puppetlabs-havana development directory.
-rm *gz
-cd puppetlabs-havana
-rm pkg/*gz
-puppet module build
-cp pkg/*gz ../.
-cd ..

--- a/examples/vagrant/05_up.sh
+++ b/examples/vagrant/05_up.sh
@@ -2,4 +2,3 @@
 # This is the script for bringing up the standard openstack nodes without
 # Swift. This is probably the up script you want to run.
 vagrant up --provider vmware_fusion puppet control storage network compute
-cp ../hiera.yaml ../common.yaml .

--- a/examples/vagrant/06_swiftup.sh
+++ b/examples/vagrant/06_swiftup.sh
@@ -2,4 +2,3 @@
 # If you want to test Swift, this is the script to run. It will bring up all of the
 # nodes necessary to run Swift.
 vagrant up --provider vmware_fusion puppet control swiftstore1 swiftstore2 swiftstore3
-cp ../hiera.yaml ../common.yaml .

--- a/examples/vagrant/10_setup_master.sh
+++ b/examples/vagrant/10_setup_master.sh
@@ -2,13 +2,15 @@
 # Set up the Puppet Master
 
 vagrant ssh puppet -c "sudo service iptables stop; \
-sudo puppet module install puppetlabs/puppetdb; \
-sudo puppet module install puppetlabs/ntp; \
-sudo puppet module install puppetlabs/mysql --version 0.6.1; \
-sudo puppet module install puppetlabs/openstack; \
-sudo puppet module install puppetlabs/mongodb; \
-sudo cp /vagrant/site.pp /etc/puppet/manifests/site.pp; \
-sudo chown root:puppet /etc/puppet/manifests/site.pp; \
+sudo rpm -i http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm; \
+sudo yum install -y puppet-server; \
+sudo yum install -y git; \
+sudo rmdir /etc/puppet/modules; \
+sudo ln -s /vagrant/modules /etc/puppet/modules; \
+sudo ln -s /vagrant/site.pp /etc/puppet/manifests/site.pp; \
+sudo gem install librarian-puppet --no-ri --no-rdoc; \
+cd /vagrant; \
+sudo librarian-puppet install --verbose --path /vagrant/modules; \
 sudo service puppetmaster start;\
 sudo puppet agent -t; \
 sudo puppet apply --modulepath /etc/puppet/modules -e \"class { '::puppetdb': listen_address => '0.0.0.0', ssl_listen_address => '0.0.0.0' } class { 'puppetdb::master::config': puppetdb_server => 'puppet'}\""

--- a/examples/vagrant/11_setup_havana.sh
+++ b/examples/vagrant/11_setup_havana.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
-# Move the Havana module to the Puppet Master
-vagrant ssh puppet -c "cd /etc/puppet/modules; \
-sudo tar -xvzf /vagrant/*gz; \
-sudo rm -rf havana
-sudo mv puppetlabs-havana* havana; \
-sudo cp /vagrant/hiera.yaml /etc/puppet/hiera.yaml; \
-sudo chown root:puppet /etc/puppet/hiera.yaml; \
-sudo mkdir /etc/puppet/hieradata; \
-sudo chown root:puppet /etc/puppet/hieradata; \
-sudo cp /etc/puppet/modules/havana/examples/common.yaml /etc/puppet/hieradata/common.yaml; \
-sudo chown root:puppet /etc/puppet/hieradata/common.yaml; \
+# Mount the Havana module on the Puppet Master
+vagrant ssh puppet -c "sudo ln -s /havana /etc/puppet/modules; \
+sudo ln -s /havana/examples/hiera.yaml /etc/puppet/hiera.yaml; \
+sudo mkdir -p /etc/puppet/hieradata; \
+sudo ln -s /havana/examples/common.yaml /etc/puppet/hieradata/common.yaml; \
 sudo service puppetmaster restart;"

--- a/examples/vagrant/Puppetfile
+++ b/examples/vagrant/Puppetfile
@@ -1,0 +1,9 @@
+forge "http://forge.puppetlabs.com"
+
+mod "puppetlabs/puppetdb"
+mod "puppetlabs/ntp"
+mod "puppetlabs/openstack"
+mod "puppetlabs/mysql", "0.6.1"
+mod "puppetlabs/mongodb"
+
+# vim:ft=ruby

--- a/examples/vagrant/Vagrantfile
+++ b/examples/vagrant/Vagrantfile
@@ -21,6 +21,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     puppet.vm.hostname = "puppet"
 
+    puppet.vm.synced_folder "../../", "/havana"
+
     puppet.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "1024"
     end

--- a/examples/vagrant/firstrun.sh
+++ b/examples/vagrant/firstrun.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-./00_package.sh
 ./05_up.sh
 ./10_setup_master.sh
 ./11_setup_havana.sh

--- a/examples/vagrant/redeploy.sh
+++ b/examples/vagrant/redeploy.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-./00_package.sh
 ./11_setup_havana.sh

--- a/examples/vagrant/swiftrun.sh
+++ b/examples/vagrant/swiftrun.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-./00_package.sh
-./05_swiftup
+./06_swiftup
 ./10_setup_master.sh
 ./11_setup_havana.sh
 ./15_setup_swiftnodes.sh


### PR DESCRIPTION
Also remove the need to sub-clone and package havana because it's mounted at /havana on the VM.
