### PR TITLE
Correct vswitch external interface detection

### DIFF
--- a/manifests/profile/neutron/router.pp
+++ b/manifests/profile/neutron/router.pp
@@ -44,16 +44,20 @@ class havana::profile::neutron::router {
     }
   }
 
-  vs_bridge { 'br-ex':
-    ensure => present,
-  }
-
+  $external_bridge = 'br-ex'
   $external_network = hiera('havana::network::external')
   $external_device = device_for_network($external_network)
-
-  vs_port { $external_device:
-    ensure  => present,
-    bridge  => 'br-ex',
-    keep_ip => true,
+  vs_bridge { $external_bridge:
+    ensure => present,
+  }
+  if $external_device != $external_bridge {
+    vs_port { $external_device:
+      ensure  => present,
+      bridge  => $external_bridge,
+      keep_ip => true,
+    }
+  } else {
+    # External bridge already has the external device's IP, thus the external
+    # device has already been linked
   }
 }


### PR DESCRIPTION
When the vswitch port is added to a bridge with `keep_ip => true` the ip address migrates to the bridge device. On the next puppet run, the `device_for_network()` will then detect the bridge instead of the original interface.

To avoid this, this commit decides that if the ip address is on the bridge device, then the `vs_port` has already been created. One caveat would be that if the external bridge name was ever changed, there would not be a way to re-link the interface from one bridge to another.

An alternative solution would be to remove `keep_ip => true`, but I don't know the implications of doing this.
