### PR TITLE
Rename router to non-munging name

### DIFF
--- a/manifests/profile/neutron/router.pp
+++ b/manifests/profile/neutron/router.pp
@@ -44,7 +44,7 @@ class havana::profile::neutron::router {
     }
   }
 
-  $external_bridge = 'br-ex'
+  $external_bridge = 'brex'
   $external_network = hiera('havana::network::external')
   $external_device = device_for_network($external_network)
   vs_bridge { $external_bridge:


### PR DESCRIPTION
The fact munger causes an interface `br-ex` to have the fact `ipaddress_br_ex` and the original interface name is lost. This changes the router interface to use a bi-directional name.
