### PR TITLE
Enable overlapping ips for l3 network namespaces

### DIFF
--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -10,12 +10,13 @@ class havana::common::neutron {
   $data_address = ip_for_network($data_network)
 
   class { '::neutron':
-    rabbit_host     => $controller_management_address,
-    core_plugin     => 'neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2',
-    rabbit_user     => hiera('havana::rabbitmq::user'),
-    rabbit_password => hiera('havana::rabbitmq::password'),
-    debug           => hiera('havana::debug'),
-    verbose         => hiera('havana::verbose'),
+    rabbit_host           => $controller_management_address,
+    core_plugin           => 'neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2',
+    allow_overlapping_ips => true,
+    rabbit_user           => hiera('havana::rabbitmq::user'),
+    rabbit_password       => hiera('havana::rabbitmq::password'),
+    debug                 => hiera('havana::debug'),
+    verbose               => hiera('havana::verbose'),
   }
 
   # everone gets an ovs agent (TODO true?)


### PR DESCRIPTION
I don't think there's any reason to have this be toggleable.
