### PR TITLE
Set tenant name to admin in /root/openrc.

### DIFF
--- a/manifests/profile/auth_file.pp
+++ b/manifests/profile/auth_file.pp
@@ -1,6 +1,7 @@
 # The profile to install an OpenStack specific mysql server
 class havana::profile::auth_file {
   class { '::openstack::auth_file':
+    admin_tenant    => 'admin',
     admin_password  => hiera('havana::keystone::admin_password'),
     region_name     => hiera('havana::region'),
     controller_node => hiera('havana::controller::address::api'),


### PR DESCRIPTION
The tenant name in /root/openrc was set to 'openstack', which is the default in openstack::auth_file. This PR will set the tennant to 'admin' as this is the tenant name set by the Havana module.
